### PR TITLE
Knack Remote Login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,18 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@reach/router": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.1.1.tgz",
+      "integrity": "sha1-JKWyDxzJ5V4svNxFT7gslNtHmoE=",
+      "requires": {
+        "create-react-context": "^0.2.1",
+        "invariant": "^2.2.3",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "warning": "^3.0.0"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -2309,6 +2321,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-context": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+      "requires": {
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -2923,6 +2944,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "enhanced-resolve": {
       "version": "3.4.1",
@@ -3691,6 +3720,35 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
         "bser": "^2.0.0"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        }
       }
     },
     "figures": {
@@ -4501,6 +4559,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "gzip-size": {
       "version": "3.0.0",
@@ -5314,6 +5377,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -6392,6 +6464,15 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
         "lower-case": "^1.1.1"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -8291,6 +8372,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.1.tgz",
       "integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-load-script": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/react-load-script/-/react-load-script-0.0.6.tgz",
@@ -9912,6 +9998,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+    },
     "uglify-js": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -10285,6 +10376,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watch": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reach/router": "^1.1.1",
     "axios": "^0.18.0",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react";
 import axios from "axios";
-import { Router, Redirect } from "@reach/router";
+import { Router, Redirect, navigate } from "@reach/router";
 
 import Login from "./Login";
+import Home from "./Home";
 import Data from "./Data";
 
 import "./App.css";
@@ -22,6 +23,7 @@ class App extends Component {
     this.viewKey = "view_1877";
 
     this.state = {
+      appId: window.app_id,
       knackUserToken: null,
       knackData: {},
       knackDataLoaded: null
@@ -32,8 +34,7 @@ class App extends Component {
     this.setState({ knackUserToken: token });
   };
 
-  requestKnackViewData = (sceneKey, viewKey) => {
-    debugger;
+  requestKnackViewData = async (sceneKey, viewKey) => {
     axios
       .get(
         `https://api.knack.com/v1/pages/${sceneKey}/views/${viewKey}/records`,
@@ -61,6 +62,9 @@ class App extends Component {
   };
 
   render() {
+    // If we're not authenticated, go back to the login page
+    !this.state.knackUserToken && navigate("/login");
+
     return (
       <div className="App">
         <header className="App-header">
@@ -68,7 +72,13 @@ class App extends Component {
         </header>
 
         <Router>
-          <Login path="/login" />
+          <Login
+            path="/login"
+            setKnackUserToken={this.setKnackUserToken}
+            knackUserToken={this.state.knackUserToken}
+            appId={this.state.appId}
+          />
+          <Home path="/" knackUserToken={this.state.knackUserToken} />
           <Data
             path="/data"
             requestKnackViewData={this.requestKnackViewData.bind(this)}

--- a/src/Data.js
+++ b/src/Data.js
@@ -1,0 +1,44 @@
+import React, { Component } from "react";
+import KnackScript from "./KnackScript";
+
+class Data extends Component {
+  render() {
+    const {
+      knackUserToken,
+      knackDataLoaded,
+      knackData,
+      requestKnackViewData,
+      setKnackUserToken,
+      sceneKey,
+      viewKey
+    } = this.props;
+
+    const hasDataBeenRequested = knackUserToken && !knackDataLoaded;
+
+    return (
+      <div>
+        {!knackUserToken && (
+          <KnackScript
+            requestKnackViewData={requestKnackViewData}
+            setKnackUserToken={setKnackUserToken}
+          />
+        )}
+
+        {knackUserToken && (
+          <span>👤 User Token Active. Requesting Data...</span>
+        )}
+
+        {hasDataBeenRequested && requestKnackViewData(sceneKey, viewKey)}
+
+        {knackDataLoaded && (
+          <div>
+            <h3>Data 🎉</h3>
+            <code>{JSON.stringify(knackData)}</code>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default Data;

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,0 +1,14 @@
+import React, { Component } from "react";
+
+class Home extends Component {
+  render() {
+    return (
+      <div>
+        <h1>🛴 home </h1>
+        <code>{this.props.knackUserToken}</code>
+      </div>
+    );
+  }
+}
+
+export default Home;

--- a/src/KnackScript.js
+++ b/src/KnackScript.js
@@ -1,0 +1,59 @@
+import React, { Component } from "react";
+import Script from "react-load-script";
+
+class KnackScript extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      scriptLoaded: null,
+      scriptError: null
+    };
+  }
+
+  handleScriptCreate = () => {
+    this.setState({ scriptLoaded: false });
+  };
+
+  handleScriptError = () => {
+    this.setState({ scriptError: true });
+  };
+
+  handleScriptLoad = () => {
+    this.setState({ scriptLoaded: true });
+
+    let KnackApp = window.Knack;
+
+    // **TODO**
+    // This request has to be delayed bc we have to wait for the Knack JS app to
+    // initialize in the browser, make a new request, and then finish. It appears
+    // this happens with websocket so maybe we can watch for a process to finish?
+    //
+    // This library might work better than react-load-script:
+    // https://github.com/leozdgao/react-async-script-loader#readme
+    setTimeout(() => {
+      this.props.setKnackUserToken(KnackApp.getUserToken());
+    }, 2000);
+  };
+
+  render() {
+    return (
+      <div>
+        {!this.state.scriptLoaded && <h2>'Loading Knack.js...'</h2>}
+        <Script
+          url={`https://loader.knack.com/${window.app_id}/dist_2/knack.js`}
+          onCreate={this.handleScriptCreate}
+          onError={this.handleScriptError}
+          onLoad={this.handleScriptLoad}
+        />
+        {this.state.scriptLoaded && (
+          <small style={{ color: "green", display: "block" }}>
+            ✅ Base App Loaded. <br />
+          </small>
+        )}
+      </div>
+    );
+  }
+}
+
+export default KnackScript;

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,0 +1,19 @@
+import React, { Component } from "react";
+
+class Login extends Component {
+  render() {
+    return (
+      <div>
+        <form action="">
+          <label htmlFor="email">Email</label>
+          <input id="email" type="text" placeholder="Email" />
+          <br />
+          <label htmlFor="password">Password</label>
+          <input id="password" type="text" placeholder="Password" />
+        </form>
+      </div>
+    );
+  }
+}
+
+export default Login;

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,15 +1,75 @@
 import React, { Component } from "react";
+import { navigate } from "@reach/router";
+import axios from "axios";
 
 class Login extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      requestMade: false,
+      email: "",
+      password: "",
+      loginError: false,
+      isLoggedIn: false
+    };
+  }
+
+  knackRemoteLogin = e => {
+    e.preventDefault();
+    axios
+      .post(
+        `https://api.knack.com/v1/applications/${this.props.appId}/session`,
+        {
+          email: this.state.email,
+          password: this.state.password,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      )
+      .then(res => {
+        console.log(res);
+        this.props.setKnackUserToken(res.data.session.user.token);
+      })
+      .then(this.setState({ isLoggedIn: true }))
+
+      .catch(error => {
+        console.log(error);
+        this.setState({ loginError: true });
+      });
+  };
+
+  handleChange = e => {
+    this.setState({ [e.target.name]: e.target.value });
+  };
+
   render() {
+    this.props.knackUserToken && navigate("/");
+
     return (
       <div>
-        <form action="">
+        {this.state.loginError && (
+          <p style={{ color: "red" }}>Email or password incorrect.</p>
+        )}
+        <form onSubmit={this.knackRemoteLogin}>
           <label htmlFor="email">Email</label>
-          <input id="email" type="text" placeholder="Email" />
+          <input
+            onChange={this.handleChange}
+            id="email"
+            name="email"
+            type="text"
+            placeholder="Email"
+          />
           <br />
           <label htmlFor="password">Password</label>
-          <input id="password" type="text" placeholder="Password" />
+          <input
+            onChange={this.handleChange}
+            id="password"
+            name="password"
+            type="text"
+            placeholder="Password"
+          />
+          <button type="submit">Login</button>
         </form>
       </div>
     );


### PR DESCRIPTION
- Add routing library for React -- Reach Router
  - We currently have three routes: 
    1. `/login` -- this uses the the [Knack Remote Login API](https://www.knack.com/developer-documentation/#remote-user-logins) to authenticate a user. Once they are logged in, we redirect them to a landing page.
    2. `/data` -- This is all the old stuff I did.
    3. `/` -- this is the landing page
- Separate logic into components and show certain components by browser path
 
 