### PR TITLE
Work order details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,14 @@
         "@fortawesome/fontawesome-common-types": "^0.2.4"
       }
     },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.3.1.tgz",
+      "integrity": "sha512-ZHMohHUxPSEUeqc7LOmO5jdeI3vlQLDgSCYR4MYk6oN7C3X59vUadLefnvctMTJyF5NWYxDbaj90ulvickDnsQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.4"
+      }
+    },
     "@fortawesome/free-solid-svg-icons": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.3.1.tgz",
@@ -2007,6 +2015,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
@@ -2226,6 +2239,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
       "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+    },
+    "consecutive": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/consecutive/-/consecutive-5.0.4.tgz",
+      "integrity": "sha1-RdJtRgT1UeWm20d/nXmb7DOi8AU="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -8376,6 +8394,16 @@
         "schedule": "^0.5.0"
       }
     },
+    "react-accessible-accordion": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/react-accessible-accordion/-/react-accessible-accordion-2.4.4.tgz",
+      "integrity": "sha512-53U2SYk6T6PLjj/NJZLo6vO/7S9GlKkm6mtxjuk2P0Qj3mlRziuL0uYHT2KfC09/4YwngSZg+3OQXubGrTApgw==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "consecutive": "^5.0.4",
+        "unstated": "^2.1.1"
+      }
+    },
     "react-dev-utils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.2.tgz",
@@ -10221,6 +10249,21 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
+    "unstated": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/unstated/-/unstated-2.1.1.tgz",
+      "integrity": "sha512-fORlTWMZxq7NuMJDxyIrrYIZKN7wEWYQ9SiaJfIRcSpsowr6Ph/JIfK2tgtXLW614JfPG/t5q9eEIhXRCf55xg==",
+      "requires": {
+        "create-react-context": "^0.1.5"
+      },
+      "dependencies": {
+        "create-react-context": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.1.6.tgz",
+          "integrity": "sha512-eCnYYEUEc5i32LHwpE/W7NlddOB9oHwsPaWtWzYtflNkkwa3IfindIcoXdVWs12zCbwaMCavKNu84EXogVIWHw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.4",
+    "@fortawesome/free-regular-svg-icons": "^5.3.1",
     "@fortawesome/free-solid-svg-icons": "^5.3.1",
     "@fortawesome/react-fontawesome": "^0.1.3",
     "@reach/router": "^1.1.1",
@@ -11,6 +12,7 @@
     "bootstrap": "^4.1.3",
     "js-cookie": "^2.2.0",
     "react": "^16.5.2",
+    "react-accessible-accordion": "^2.4.4",
     "react-dom": "^16.5.2",
     "react-load-script": "0.0.6",
     "react-scripts": "1.1.5"

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,13 @@
+.atd-spinner {
+  animation: spinner 1s infinite;
+  margin: auto;
+  display: block;
+}
+@keyframes spinner {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/Home.js
+++ b/src/Home.js
@@ -34,7 +34,7 @@ class Home extends Component {
           <FontAwesomeIcon icon={faHome} /> Home
         </h1>
 
-        <ul className="list-group">
+        <ul className="list-group-flush list-group">
           {mainPages.map(page => (
             <li className="list-group-item">
               <Link to={page.link}>

--- a/src/MarkingsDetail.js
+++ b/src/MarkingsDetail.js
@@ -6,7 +6,8 @@ import {
   faWrench,
   faInfoCircle,
   faClipboard,
-  faPaperclip
+  faPaperclip,
+  faSpinner
 } from "@fortawesome/free-solid-svg-icons";
 
 import {
@@ -17,7 +18,7 @@ import {
 } from "react-accessible-accordion";
 import "react-accessible-accordion/dist/fancy-example.css";
 
-const fields = [
+const detailsFields = [
   { "Street Segment ID": "field_2591" },
   { Status: "field_2181" },
   { "Work Groups": "field_2203" },
@@ -39,29 +40,80 @@ class MarkingsDetail extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      markingDetailData: []
+      markingDetailData: false,
+      commentsData: false,
+      jobsData: false,
+      attachmentsData: false
+    };
+    this.requestOptions = {
+      headers: {
+        "X-Knack-Application-Id": "5b633d68c04cc40730078ac3",
+        "X-Knack-REST-API-KEY": "knack",
+        Authorization: this.props.knackUserToken,
+        "content-type": "application/json"
+      }
     };
   }
+
   componentDidMount() {
+    this.requestMarkingDetailsData();
+  }
+
+  requestMarkingDetailsData = () => {
     axios
       .get(
         `https://us-api.knack.com/v1/scenes/scene_713/views/view_1885/records/${
           this.props.markingId
         }`,
-        {
-          headers: {
-            "X-Knack-Application-Id": "5b633d68c04cc40730078ac3",
-            "X-Knack-REST-API-KEY": "knack",
-            Authorization: this.props.knackUserToken,
-            "content-type": "application/json"
-          }
-        }
+        this.requestOptions
       )
       .then(res => {
         console.log(res);
         this.setState({ markingDetailData: res.data });
       });
-  }
+  };
+
+  requestCommentsData = () => {
+    axios
+      .get(
+        `https://us-api.knack.com/v1/scenes/scene_713/views/view_1953/records?view-work-orders-marking-details_id=/${
+          this.props.markingId
+        }`,
+        this.requestOptions
+      )
+      .then(res => {
+        console.log("commentsData", res);
+        this.setState({ commentsData: res.data.records });
+      });
+  };
+
+  requestJobsData = () => {
+    axios
+      .get(
+        `https://us-api.knack.com/v1/scenes/scene_713/views/view_2158/records?view-work-orders-marking-details_id=${
+          this.props.markingId
+        }`,
+        this.requestOptions
+      )
+      .then(res => {
+        console.log("jobsData", res);
+        this.setState({ jobsData: res.data.records });
+      });
+  };
+
+  requestAttachmentsData = () => {
+    axios
+      .get(
+        `https://us-api.knack.com/v1/scenes/scene_713/views/view_1975/records?view-work-orders-marking-details_id=${
+          this.props.markingId
+        }`,
+        this.requestOptions
+      )
+      .then(res => {
+        console.log("attachmentsData", res);
+        this.setState({ attachmentsData: res.data.records });
+      });
+  };
 
   render() {
     return (
@@ -73,12 +125,13 @@ class MarkingsDetail extends Component {
         <Accordion>
           <AccordionItem>
             <AccordionItemTitle>
-              <h3>
+              <h3 className="u-position-relative">
                 <FontAwesomeIcon icon={faInfoCircle} /> Marking Details
+                <div className="accordion__arrow" role="presentation" />
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
-              {fields.map(field => (
+              {detailsFields.map(field => (
                 <dl>
                   <dt>{Object.keys(field)[0]}</dt>
                   <dd>
@@ -88,35 +141,105 @@ class MarkingsDetail extends Component {
               ))}
             </AccordionItemBody>
           </AccordionItem>
-          <AccordionItem>
+          <AccordionItem onClick={this.requestCommentsData}>
             <AccordionItemTitle>
-              <h3>
+              <h3 className="u-position-relative">
                 <FontAwesomeIcon icon={faComments} /> Comments
+                <div className="accordion__arrow" role="presentation" />
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
-              <p>Body content</p>
+              {this.state.commentsData.length === 0 && <p>No data</p>}
+              {this.state.commentsData.length > 0 && (
+                <ul className="list-group list-group-flush">
+                  {this.state.commentsData.map(comment => (
+                    <li className="list-group-item d-flex row">
+                      <div className="col-12">{comment.field_2192}</div>
+                      <div className="col-6">{comment.field_2193}</div>
+                      <div
+                        className="col-6"
+                        dangerouslySetInnerHTML={{ __html: comment.field_2194 }}
+                      >
+                        {}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {!this.state.commentsData && (
+                <div>
+                  <FontAwesomeIcon
+                    icon={faSpinner}
+                    size="2x"
+                    className="atd-spinner"
+                  />
+                </div>
+              )}
             </AccordionItemBody>
           </AccordionItem>
-          <AccordionItem>
+          <AccordionItem onClick={this.requestJobsData}>
             <AccordionItemTitle>
-              <h3>
-                {" "}
+              <h3 className="u-position-relative">
                 <FontAwesomeIcon icon={faClipboard} /> Jobs
+                <div className="accordion__arrow" role="presentation" />
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
-              <p>Body content</p>
+              {this.state.jobsData.length === 0 && <p>No data</p>}
+              {this.state.jobsData.length > 0 && (
+                <ul className="list-group list-group-flush">
+                  {this.state.jobsData.map(comment => (
+                    <li className="list-group-item d-flex row">
+                      <div className="col-12">{comment.field_2173}</div>
+                      <div className="col-6">{comment.field_2190}</div>
+                      <div
+                        className="col-6"
+                        dangerouslySetInnerHTML={{ __html: comment.field_2196 }}
+                      >
+                        {}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {!this.state.jobsData && (
+                <div>
+                  <FontAwesomeIcon
+                    icon={faSpinner}
+                    size="2x"
+                    className="atd-spinner"
+                  />
+                </div>
+              )}
             </AccordionItemBody>
           </AccordionItem>
-          <AccordionItem>
+          <AccordionItem onClick={this.requestAttachmentsData}>
             <AccordionItemTitle>
-              <h3>
+              <h3 className="u-position-relative">
                 <FontAwesomeIcon icon={faPaperclip} /> Attachments
+                <div className="accordion__arrow" role="presentation" />
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
-              <p>Body content</p>
+              {this.state.attachmentsData.length === 0 && <p>No data</p>}
+              {this.state.attachmentsData.length > 0 && (
+                <ul className="list-group list-group-flush">
+                  {this.state.attachmentsData.map(comment => (
+                    <li className="list-group-item d-flex row">
+                      <div className="col-12">{comment.field_2403}</div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {!this.state.attachmentsData && (
+                <div>
+                  <FontAwesomeIcon
+                    icon={faSpinner}
+                    size="2x"
+                    className="atd-spinner"
+                  />
+                </div>
+              )}
             </AccordionItemBody>
           </AccordionItem>
         </Accordion>

--- a/src/MarkingsDetail.js
+++ b/src/MarkingsDetail.js
@@ -1,7 +1,21 @@
 import React, { Component } from "react";
 import axios from "axios";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faWrench } from "@fortawesome/free-solid-svg-icons";
+import { faComments } from "@fortawesome/free-regular-svg-icons";
+import {
+  faWrench,
+  faInfoCircle,
+  faClipboard,
+  faPaperclip
+} from "@fortawesome/free-solid-svg-icons";
+
+import {
+  Accordion,
+  AccordionItem,
+  AccordionItemTitle,
+  AccordionItemBody
+} from "react-accessible-accordion";
+import "react-accessible-accordion/dist/fancy-example.css";
 
 const fields = [
   { "Street Segment ID": "field_2591" },
@@ -25,26 +39,9 @@ class MarkingsDetail extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      markingDetailData: [],
-      open: false
+      markingDetailData: []
     };
   }
-
-  toggleCollaspingPanel = () => {
-    this.setState({ open: !this.state.open });
-  };
-
-  renderCollapsingClass() {
-    let klass = "";
-
-    if (this.state.open) {
-      klass = "collapse show";
-    } else {
-      klass = "collapse";
-    }
-    return klass;
-  }
-
   componentDidMount() {
     axios
       .get(
@@ -73,43 +70,56 @@ class MarkingsDetail extends Component {
           <FontAwesomeIcon icon={faWrench} />{" "}
           {this.state.markingDetailData.field_2287}
         </h1>
-        <div className="accordion" id="accordionExample">
-          <div className="card">
-            <div className="card-header" id="headingOne">
-              <h5 className="mb-0">
-                <button
-                  className="btn btn-link"
-                  type="button"
-                  data-toggle="collapse"
-                  data-target="#collapseOne"
-                  aria-expanded="true"
-                  aria-controls="collapseOne"
-                  onClick={this.toggleCollaspingPanel}
-                >
-                  Marking Details
-                </button>
-              </h5>
-            </div>
-
-            <div
-              id="collapseOne"
-              className={this.renderCollapsingClass()}
-              aria-labelledby="headingOne"
-              data-parent="#accordionExample"
-            >
-              <div class="card-body">
-                {fields.map(field => (
-                  <dl>
-                    <dt>{Object.keys(field)[0]}</dt>
-                    <dd>
-                      {this.state.markingDetailData[Object.values(field)[0]]}
-                    </dd>
-                  </dl>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
+        <Accordion>
+          <AccordionItem>
+            <AccordionItemTitle>
+              <h3>
+                <FontAwesomeIcon icon={faInfoCircle} /> Marking Details
+              </h3>
+            </AccordionItemTitle>
+            <AccordionItemBody>
+              {fields.map(field => (
+                <dl>
+                  <dt>{Object.keys(field)[0]}</dt>
+                  <dd>
+                    {this.state.markingDetailData[Object.values(field)[0]]}
+                  </dd>
+                </dl>
+              ))}
+            </AccordionItemBody>
+          </AccordionItem>
+          <AccordionItem>
+            <AccordionItemTitle>
+              <h3>
+                <FontAwesomeIcon icon={faComments} /> Comments
+              </h3>
+            </AccordionItemTitle>
+            <AccordionItemBody>
+              <p>Body content</p>
+            </AccordionItemBody>
+          </AccordionItem>
+          <AccordionItem>
+            <AccordionItemTitle>
+              <h3>
+                {" "}
+                <FontAwesomeIcon icon={faClipboard} /> Jobs
+              </h3>
+            </AccordionItemTitle>
+            <AccordionItemBody>
+              <p>Body content</p>
+            </AccordionItemBody>
+          </AccordionItem>
+          <AccordionItem>
+            <AccordionItemTitle>
+              <h3>
+                <FontAwesomeIcon icon={faPaperclip} /> Attachments
+              </h3>
+            </AccordionItemTitle>
+            <AccordionItemBody>
+              <p>Body content</p>
+            </AccordionItemBody>
+          </AccordionItem>
+        </Accordion>
       </div>
     );
   }

--- a/src/MarkingsDetail.js
+++ b/src/MarkingsDetail.js
@@ -1,17 +1,53 @@
 import React, { Component } from "react";
 import axios from "axios";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faWrench } from "@fortawesome/free-solid-svg-icons";
+
+const fields = [
+  { "Street Segment ID": "field_2591" },
+  { Status: "field_2181" },
+  { "Work Groups": "field_2203" },
+  { Area: "field_2164" },
+  { School: "field_2171" },
+  { "Needs Coordination": "field_2204" },
+  { Instructions: "field_2169" },
+  { ID: "field_2160" },
+  { "Work Type": "field_2292" },
+  { Requester: "field_2162" },
+  { "Requester Work Order ID": "field_2400" },
+  { "Created By": "field_2146" },
+  { "Created Date": "field_2148" },
+  { "Modified Date": "field_2150" },
+  { "Modified By": "field_2149" }
+];
 
 class MarkingsDetail extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      markingDetailData: []
+      markingDetailData: [],
+      open: false
     };
   }
+
+  toggleCollaspingPanel = () => {
+    this.setState({ open: !this.state.open });
+  };
+
+  renderCollapsingClass() {
+    let klass = "";
+
+    if (this.state.open) {
+      klass = "collapse show";
+    } else {
+      klass = "collapse";
+    }
+    return klass;
+  }
+
   componentDidMount() {
     axios
       .get(
-        // TODO: figure out which of these calls I need and consolidate
         `https://us-api.knack.com/v1/scenes/scene_713/views/view_1885/records/${
           this.props.markingId
         }`,
@@ -33,8 +69,47 @@ class MarkingsDetail extends Component {
   render() {
     return (
       <div>
-        <h1>{this.state.markingDetailData.field_2287}</h1>
-        <code>{JSON.stringify(this.state.markingDetailData)}</code>
+        <h1>
+          <FontAwesomeIcon icon={faWrench} />{" "}
+          {this.state.markingDetailData.field_2287}
+        </h1>
+        <div className="accordion" id="accordionExample">
+          <div className="card">
+            <div className="card-header" id="headingOne">
+              <h5 className="mb-0">
+                <button
+                  className="btn btn-link"
+                  type="button"
+                  data-toggle="collapse"
+                  data-target="#collapseOne"
+                  aria-expanded="true"
+                  aria-controls="collapseOne"
+                  onClick={this.toggleCollaspingPanel}
+                >
+                  Marking Details
+                </button>
+              </h5>
+            </div>
+
+            <div
+              id="collapseOne"
+              className={this.renderCollapsingClass()}
+              aria-labelledby="headingOne"
+              data-parent="#accordionExample"
+            >
+              <div class="card-body">
+                {fields.map(field => (
+                  <dl>
+                    <dt>{Object.keys(field)[0]}</dt>
+                    <dd>
+                      {this.state.markingDetailData[Object.values(field)[0]]}
+                    </dd>
+                  </dl>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/MarkingsDetail.js
+++ b/src/MarkingsDetail.js
@@ -226,7 +226,16 @@ class MarkingsDetail extends Component {
                 <ul className="list-group list-group-flush">
                   {this.state.attachmentsData.map(comment => (
                     <li className="list-group-item d-flex row">
-                      <div className="col-12">{comment.field_2403}</div>
+                      <div className="col-4">{comment.field_2403}</div>
+                      <div className="col-4">{comment.field_2407}</div>
+                      <div
+                        className="col-4"
+                        dangerouslySetInnerHTML={{ __html: comment.field_2406 }}
+                      />
+                      <div
+                        className="col-12"
+                        dangerouslySetInnerHTML={{ __html: comment.field_2405 }}
+                      />
                     </li>
                   ))}
                 </ul>

--- a/src/MyWorkOrders.js
+++ b/src/MyWorkOrders.js
@@ -53,7 +53,7 @@ class MyWorkOrders extends Component {
         <h1>
           <FontAwesomeIcon icon={faStreetView} /> My Work Orders
         </h1>
-        <ul className="list-group">
+        <ul className="list-group list-group-flush">
           {isMyJobsDataLoaded &&
             myWorkOrdersData.map(item => (
               <Link to={`/markings/${item.id}`} key={item.id}>


### PR DESCRIPTION
Closes #3 

In this view of a single work order item, each category of data about the item is in a collapsable panel. There are 4 separate API calls made to gather the data for this page. The markings details come first on page load and the other 3 happen as ad-hoc requests when a user opens a panel for more data. 

There's a lot of room to refactor this code into reusable components. Same for optimizing the API requests.

From here, there are two main things to work on next. 
1. Making the Jobs section link to a Job Details Page and creating that layout.
2. Work on non-get API actions from this page like Add a Comment, Add an Attachment and Edit the Work Order.

![2018-09-28 17 50 25](https://user-images.githubusercontent.com/5697474/46236954-18be0200-c347-11e8-8106-16934f339ca3.gif)