### PR TITLE
Reopen work order 

### DIFF
--- a/src/components/WorkOrder/formConfig.js
+++ b/src/components/WorkOrder/formConfig.js
@@ -42,7 +42,8 @@ export const FIELDS = {
   WORK_TYPE_SCHEDULED_WORK: "field_900",
   WORK_TYPE_OTHER: "field_1420",
   WORK_SCHEDULED_DATE: "field_460",
-  TASK_ORDERS: "field_2634"
+  TASK_ORDERS: "field_2634",
+  STATUS: "field_459"
 };
 
 export const ASSET_TYPE_OPTIONS = [

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -9,7 +9,8 @@ import {
   faBarcode,
   faSpinner,
   faEdit,
-  faFlagCheckered
+  faFlagCheckered,
+  faUndo
 } from "@fortawesome/free-solid-svg-icons";
 
 import {
@@ -23,6 +24,7 @@ import "react-accessible-accordion/dist/fancy-example.css";
 import api from "../queries/api";
 import { workOrderFields } from "../queries/fields";
 import { getWorkOrderDetails, getWorkOrderTitle } from "./WorkOrder/helpers";
+import { FIELDS } from "./WorkOrder/formConfig";
 
 class WorkOrderDetail extends Component {
   constructor(props) {
@@ -80,6 +82,16 @@ class WorkOrderDetail extends Component {
       .then(res => this.setState({ imagesData: res.data.records }));
   };
 
+  handleReopenWorkOrder = () => {
+    api
+      .workOrder()
+      .reopen(this.props.match.params.workOrderId)
+      .then(res => {
+        console.log(res);
+        this.setState({});
+      });
+  };
+
   render() {
     return (
       <div>
@@ -87,34 +99,53 @@ class WorkOrderDetail extends Component {
           <FontAwesomeIcon icon={faWrench} />{" "}
           {this.state.titleData[workOrderFields.header]}
         </h1>
-        <div className="container">
+        <div className="container mb-3">
           <div className="row">
-            <div className="mb-3">
-              <Link
-                to={`/work-order/edit/${this.props.match.params.workOrderId}`}
+            {/* Show Re-Open Button when Work Order is Submitted */}
+            {this.state.detailsData[FIELDS.STATUS] === "Submitted" && (
+              <div
+                className="btn btn-secondary"
+                onClick={this.handleReopenWorkOrder}
               >
-                <div className="btn btn-secondary">
-                  <FontAwesomeIcon icon={faEdit} /> Edit Work Order
-                </div>
-              </Link>
-            </div>
-            <div className="ml-2">
-              {this.state.timeLogData.length > 0 ? (
-                <Link
-                  to={`/work-order/submit/${
-                    this.props.match.params.workOrderId
-                  }`}
-                >
-                  <div className={"btn btn-secondary"}>
-                    <FontAwesomeIcon icon={faFlagCheckered} /> Submit Work Order
+                <FontAwesomeIcon icon={faUndo} /> Re-Open Work Order
+              </div>
+            )}
+
+            {/* Once Field Status is loaded from state, show Edit and Submit button 
+            // if it isn't already in Submitted Status */}
+            {this.state.detailsData[FIELDS.STATUS] &&
+              this.state.detailsData[FIELDS.STATUS] !== "Submitted" && (
+                <>
+                  <Link
+                    to={`/work-order/edit/${
+                      this.props.match.params.workOrderId
+                    }`}
+                  >
+                    <div className="btn btn-secondary">
+                      <FontAwesomeIcon icon={faEdit} /> Edit Work Order
+                    </div>
+                  </Link>
+                  <div className="ml-2">
+                    {this.state.timeLogData.length > 0 ? (
+                      <Link
+                        to={`/work-order/submit/${
+                          this.props.match.params.workOrderId
+                        }`}
+                      >
+                        <div className={"btn btn-secondary"}>
+                          <FontAwesomeIcon icon={faFlagCheckered} /> Submit Work
+                          Order
+                        </div>
+                      </Link>
+                    ) : (
+                      <div className="btn btn-secondary disabled" disabled>
+                        <FontAwesomeIcon icon={faFlagCheckered} /> Submit Work
+                        Order
+                      </div>
+                    )}
                   </div>
-                </Link>
-              ) : (
-                <div className="btn btn-secondary disabled" disabled>
-                  <FontAwesomeIcon icon={faFlagCheckered} /> Submit Work Order
-                </div>
+                </>
               )}
-            </div>
           </div>
         </div>
         <Accordion>

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -21,6 +21,10 @@ const keys = {
     sceneId: "scene_450",
     viewId: "view_1280"
   },
+  reopenWorkOrder: {
+    sceneId: "scene_345",
+    viewId: "view_992"
+  },
   newWorkOrder: {
     sceneId: "scene_337",
     viewId: "view_1672",
@@ -130,6 +134,13 @@ const api = {
             keys.submitWorkoder.sceneId
           }/views/${keys.submitWorkoder.viewId}/records/${id}`,
           data,
+          getHeaders()
+        ),
+      reopen: id =>
+        axios.put(
+          `https://us-api.knack.com/v1/scenes/${
+            keys.reopenWorkOrder.sceneId
+          }/views/${keys.reopenWorkOrder.viewId}/records/${id}/`,
           getHeaders()
         ),
       editNewWorkOrder: (id, data) =>


### PR DESCRIPTION
Once a Work Order has a status field === "Submitted", we shouldn't show the Edit and Submit buttons, but instead show a Reopen button.

This wasn't captured in an issue and I got stuck on the api query (errors with 401 Unauthorized) but I think this idea is worth keeping. Going to come back to it later...