### PR TITLE
Update scene/view IDs to use new form with proper conditional rules

### DIFF
--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -22,8 +22,8 @@ const keys = {
     viewId: "view_1280"
   },
   newWorkOrder: {
-    sceneId: "scene_337",
-    viewId: "view_1672",
+    sceneId: "scene_979",
+    viewId: "view_2466",
     cameraFieldId: "field_1862",
     schoolZoneFieldId: "field_1871",
     signalFieldId: "field_1060",


### PR DESCRIPTION
Closes #72 

With fixes in place on the Knack side, self-assigning set to Yes does add the newly created Work Order to the My Work Orders page and correctly changes the status to "Assigned" and assigned the current user as the lead tech.